### PR TITLE
Autodetect release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Simply download the binary for your platform from [the release page](https://git
 Creating a release and attaching all binaries:
 
 ```bash
-keeparelease -t 1.1.1 \
+keeparelease \
   -a keeparelease-1.1.1-darwin-amd64 \
   -a keeparelease-1.1.1-linux-amd64 \
   -a keeparelease-1.1.1-windows-amd64

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,10 @@ var rootCmd = &cobra.Command{
 		// Prepare the release.
 		tag, err := cmd.Flags().GetString("tag")
 		utils.Check(err)
+		if tag == "" {
+			tag, err = keeparelease.GetTag()
+			utils.Check(err)
+		}
 		params := &github.Release{
 			TagName: tag,
 			Name:    title,

--- a/keeparelease/keeparelease.go
+++ b/keeparelease/keeparelease.go
@@ -1,8 +1,10 @@
 package keeparelease
 
 import (
+	"bytes"
 	"errors"
 	"io/ioutil"
+	"os/exec"
 	"regexp"
 	"strings"
 
@@ -81,4 +83,15 @@ func trimEdges(s, cutset string) string {
 	trimmed := strings.TrimLeft(s, " \n")
 	trimmed = strings.TrimRight(trimmed, " \n")
 	return trimmed
+}
+
+func GetTag() (string, error) {
+	cmd := exec.Command("git", "describe")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
 }


### PR DESCRIPTION
Instead of asking the users to provide the tag to release, `keeparelease`
will attempt to detect it automatically. The users still have the ability
to override the tag if they feel the need.